### PR TITLE
Fix 'apresentation' to 'presentation'

### DIFF
--- a/src/components/HomeHero/index.tsx
+++ b/src/components/HomeHero/index.tsx
@@ -13,7 +13,7 @@ export default function HomeHero() {
         </TextContainer>
         <InfosContainer>
           <CodeItem data-aos="zoom-in">
-            <span className="comment">//My apresentation</span>
+            <span className="comment">// My presentation</span>
             <span className="infos">Infos</span> {'\u007B'}
             <div>
               Name:{' '}


### PR DESCRIPTION
Another option would be 'about me' instead of  'my presentation'.